### PR TITLE
Fix GitHub Actions workflow branch configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Begin CI
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 22
       - name: Clean install
@@ -26,11 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Begin CI
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: master
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,11 +2,11 @@ name: Tests
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths-ignore:
       - '**.md'
   pull_request:
-    branches: [master]
+    branches: [main]
     paths-ignore:
       - '**.md'
 


### PR DESCRIPTION
## Summary

This PR fixes the GitHub Actions workflow configuration to properly trigger on pull requests and pushes to the `main` branch.

## Problem

The workflow was configured to trigger on the `master` branch, but the repository's default branch is `main`. This caused workflows to not trigger when creating PRs targeting `main`.

## Changes

- Updated `.github/workflows/tests.yml` to target `main` instead of `master`
- Updated GitHub Actions versions to latest (`checkout@v4`, `setup-node@v4`) for better compatibility and security

## Testing

- All existing tests pass
- Pre-commit hooks (linting, formatting, tests) executed successfully

This should resolve the issue where GitHub Actions workflows weren't being triggered for recent pull requests.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author