### PR TITLE
Fix publish workflow branch reference

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Begin CI
         uses: actions/checkout@v4
         with:
-          ref: master
+          ref: main
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
### Summary

This PR fixes the publish workflow by updating the branch reference from `master` to `main` to match the repository's default branch.

### Details

- Updated the `ref` parameter in the checkout action from `master` to `main` in `.github/workflows/publish.yml`
- This ensures the publish workflow checks out the correct default branch

### Related Issues

This fixes a potential issue where the publish workflow might fail or behave unexpectedly due to referencing a non-existent `master` branch.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author